### PR TITLE
Paths with non-ASCII characters are not handled well on Windows with non-UTF codepage

### DIFF
--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -10275,7 +10275,7 @@ utf8_to_utf16(const char *src, MDB_name *dst, int xtra)
 	int rc, need = 0;
 	wchar_t *result = NULL;
 	for (;;) {					/* malloc result, then fill it in */
-		need = MultiByteToWideChar(CP_UTF8, 0, src, -1, result, need);
+		need = MultiByteToWideChar(CP_ACP, 0, src, -1, result, need);  /* Use ACP for current Windows codepage */
 		if (!need) {
 			rc = ErrCode();
 			free(result);


### PR DESCRIPTION
On Windows OS with non-UTF code page (e.g. Hungarian language Windows), paths with non-ASCII characters are not handled properly, and DB files cannot be opened.

In such case paths are transformed using MultiByteToWideChar() (within utf8_to_utf16()), but always with the CP_UTF8 codepage. The CreateFileW() API call does not handle this path, if the local codepage is not UTF8. Correct would be using CP_ACP, which is the system default Windows ANSI code page (see https://docs.microsoft.com/en-us/windows/desktop/api/stringapiset/nf-stringapiset-multibytetowidechar).

In the mikron_node project, this causes a startup failure, see:
mikroncoin/mikron_node#33